### PR TITLE
Support for OTP 21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,5 @@ c_src/*.o
 .eunit/*
 .#*
 deps/*
-.rebar
+.rebar*
 erl_crash.dump

--- a/src/ehmon.erl
+++ b/src/ehmon.erl
@@ -63,7 +63,7 @@ report(State) ->
 %%====================================================================
 
 report_props(Info) ->
-    IO = proplists:get_value(check_io, Info),
+    IO = get_io_info(proplists:get_value(check_io, Info)),
     [{rq, proplists:get_value(run_queue, Info)}
      ,{cswit, proplists:get_value(context_switches, Info)}
      ,{otp, proplists:get_value(otp_release, Info)}
@@ -81,6 +81,11 @@ report_props(Info) ->
      ,{membin, proplists:get_value(binary, Info)}
      ,{memcode, proplists:get_value(code, Info)}
     ].
+
+get_io_info([Head, _Tail]) -> 
+    Head;
+get_io_info(List) -> 
+    List.
 
 report_string(Report) ->
    string:join([ [atom_to_list(K), "=", format_value(V)]


### PR DESCRIPTION
Ticket: [ehmon not reporting](https://app.asana.com/0/810933294009540/928182177163593)

I haven't found en explanation in the docs but the fact is that `erlang:system_info(check_io)` returns a _list of tuples_ when called on OTP 20, and a _list of lists of tuples_ when called on OTP 21. The head item of the list in latter case is identical to the list returned in former case. This PR is to support both of the implementations. 