### PR TITLE
fix: address compiler warnings

### DIFF
--- a/src/ehmon_app.erl
+++ b/src/ehmon_app.erl
@@ -59,7 +59,7 @@ a_start(App, Type) ->
     start_ok(App, Type, application:start(App, Type)).
 
 start_ok(_App, _Type, ok) -> ok;
-start_ok(_App, _Type, {error, {already_started, _App}}) -> ok;
+start_ok(_App, _Type, {error, {already_started, _}}) -> ok;
 start_ok(App, Type, {error, {not_started, Dep}}) ->
     ok = a_start(Dep, Type),
     a_start(App, Type);

--- a/src/ehmon_report_srv.erl
+++ b/src/ehmon_report_srv.erl
@@ -86,9 +86,9 @@ do_report(RState) ->
         {M, F} = ehmon_app:config(report_mf, {ehmon, stdout_report}),
         erlang:apply(M, F, [ehmon:report(RState)])
     catch
-        Class:Err ->
+        Class:Err:Stacktrace ->
             ?ERR("class=~p err=~p stack=\"~p\"",
-                 [Class, Err, erlang:get_stacktrace()])
+                 [Class, Err, Stacktrace])
     end.
 
 


### PR DESCRIPTION
```
src/ehmon_app.erl:62:10: Warning: variable '_App' is bound multiple times in this pattern.
If you mean to ignore this value, use '_' or
a different underscore-prefixed name
src/ehmon_app.erl:62:49: Warning: variable '_App' is bound multiple times in this pattern.
If you mean to ignore this value, use '_' or
a different underscore-prefixed name

src/ehmon_report_srv.erl:91:31: Warning: erlang:get_stacktrace/0 is removed; use the new try/catch syntax for retrieving the stack backtrace
```